### PR TITLE
Fix linking issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,9 @@ target_sources(amongoc
         FILES ${src_headers}
 )
 
+# Prevent any code from emitting a `neo_assert` that would require downstream linking
+target_compile_definitions(amongoc PRIVATE NEO_ENABLE_CHECKS=0)
+
 # Enable C++23 features on the target
 # We currently only use C++23 for `auto(). Future revisions
 # can remove these requirements for greater portability.

--- a/docs/dev/guidelines.rst
+++ b/docs/dev/guidelines.rst
@@ -332,11 +332,11 @@ wrapped in :cpp:`extern "C"`.
 **********************************
 
 If a C function is declared |inline| *and not* |static|, then there *must* exist
-an :cpp:`extern inline` declaration of that function in *exactly one* C
-translation unit. This differs from C++, where an |inline| function is emitted
-in each TU in which it is used, and the linker merges them at the final step. In
-C, this consolidation must be done explicitly using an :cpp:`extern inline`
-declaration.
+an :cpp:`extern inline` declaration of that function in *exactly one* **C**
+translation unit (not in a C++ translation unit). This differs from C++, where
+an |inline| function is emitted in each TU in which it is used, and the linker
+merges them at the final step. In C, this consolidation must be done explicitly
+using an :cpp:`extern inline` declaration.
 
 .. note:: There is no way to automatically verify this, because it will only
   generate an error if the compiler decides *not* to do the inlining and expects

--- a/src/amongoc/client.cpp
+++ b/src/amongoc/client.cpp
@@ -62,5 +62,3 @@ void amongoc_client_delete(amongoc_client* cl) noexcept {
 amongoc_loop* amongoc_client_get_event_loop(amongoc_client const* cl) noexcept {
     return &cl->_pool.loop();
 }
-
-extern inline mlib_allocator amongoc_client_get_allocator(amongoc_client const* cl) noexcept;

--- a/src/amongoc/collection.c
+++ b/src/amongoc/collection.c
@@ -1,0 +1,35 @@
+#include <amongoc/collection.h>
+
+extern inline amongoc_emitter amongoc_delete_one(amongoc_collection*          coll,
+                                                 bson_view                    filter,
+                                                 amongoc_delete_params const* params) mlib_noexcept;
+
+extern inline amongoc_emitter
+amongoc_delete_many(amongoc_collection*                 coll,
+                    bson_view                           filter,
+                    struct amongoc_delete_params const* params) mlib_noexcept;
+
+extern inline amongoc_emitter amongoc_insert_one(amongoc_collection*          coll,
+                                                 bson_view                    doc,
+                                                 amongoc_insert_params const* params) mlib_noexcept;
+
+extern inline amongoc_emitter
+amongoc_find_one_and_delete(amongoc_collection*             coll,
+                            bson_view                       filter,
+                            const amongoc_find_plus_params* params) mlib_noexcept;
+
+extern inline amongoc_emitter
+amongoc_find_one_and_replace(amongoc_collection*             coll,
+                             bson_view                       filter,
+                             bson_view                       replacement,
+                             const amongoc_find_plus_params* params) mlib_noexcept;
+
+extern inline amongoc_emitter
+amongoc_find_one_and_update(amongoc_collection*             coll,
+                            bson_view                       filter,
+                            bson_view const*                update_or_pipeline,
+                            size_t                          pipeline_len,
+                            const amongoc_find_plus_params* params) mlib_noexcept;
+
+extern inline mlib_allocator
+amongoc_collection_get_allocator(amongoc_collection const* coll) mlib_noexcept;

--- a/src/amongoc/collection.cpp
+++ b/src/amongoc/collection.cpp
@@ -22,37 +22,6 @@
 
 using namespace amongoc;
 
-extern inline amongoc_emitter amongoc_delete_one(amongoc_collection*          coll,
-                                                 bson_view                    filter,
-                                                 amongoc_delete_params const* params) noexcept;
-
-extern inline amongoc_emitter
-amongoc_delete_many(amongoc_collection*                 coll,
-                    bson_view                           filter,
-                    struct amongoc_delete_params const* params) noexcept;
-
-extern inline amongoc_emitter amongoc_insert_one(amongoc_collection           coll,
-                                                 bson_view                    doc,
-                                                 amongoc_insert_params const* params) mlib_noexcept;
-
-extern inline amongoc_emitter
-amongoc_find_one_and_delete(amongoc_collection*             coll,
-                            bson_view                       filter,
-                            const amongoc_find_plus_params* params) mlib_noexcept;
-
-extern inline amongoc_emitter
-amongoc_find_one_and_replace(amongoc_collection*             coll,
-                             bson_view                       filter,
-                             bson_view                       replacement,
-                             const amongoc_find_plus_params* params) mlib_noexcept;
-
-extern inline amongoc_emitter
-amongoc_find_one_and_update(amongoc_collection*             coll,
-                            bson_view                       filter,
-                            bson_view const*                update_or_pipeline,
-                            size_t                          pipeline_len,
-                            const amongoc_find_plus_params* params) mlib_noexcept;
-
 constexpr const amongoc_status_category_vtable amongoc_crud_category = {
     .name = [] { return "amongoc.crud"; },
     .strdup_message =
@@ -114,9 +83,6 @@ _parse_cursor(::amongoc_collection& coll, int batch_size, bson_view resp) {
 void amongoc_collection_delete(amongoc_collection* coll) noexcept {
     mlib::delete_via_associated_allocator(coll);
 }
-
-extern inline mlib_allocator
-amongoc_collection_get_allocator(amongoc_collection const* coll) noexcept;
 
 amongoc_client* amongoc_collection_get_client(amongoc_collection const* coll) noexcept {
     return &coll->client;
@@ -368,7 +334,7 @@ emitter amongoc_cursor_next(amongoc_cursor curs_) noexcept {
  */
 static mlib::unique<amongoc_write_result>
 _parse_write_result(bson_view resp,
-                    int64_t(amongoc_write_result::*n_field),
+                    int64_t(amongoc_write_result::* n_field),
                     mlib::allocator<> alloc) {
     mlib::unique<amongoc_write_result> ret;
     using namespace bson::parse;

--- a/src/amongoc/status.c
+++ b/src/amongoc/status.c
@@ -1,0 +1,3 @@
+#include <amongoc/status.h>
+
+extern inline amongoc_status const* _amongocStatusGetOkayStatus(void) mlib_noexcept;

--- a/src/amongoc/status.cpp
+++ b/src/amongoc/status.cpp
@@ -10,8 +10,6 @@
 
 using namespace amongoc;
 
-extern inline amongoc_status const* _amongocStatusGetOkayStatus(void) noexcept;
-
 namespace {
 
 class unknown_error_category : public std::error_category {

--- a/tests/consume/simple/test.c
+++ b/tests/consume/simple/test.c
@@ -12,6 +12,7 @@ int main() {
     amongoc_operation op = amongoc_tie(em, &status, &box, mlib_default_allocator);
     amongoc_start(&op);
     amongoc_operation_delete(op);
+    printf("%p", &amongoc_insert_one);  // Checks linking
     assert(status.code == 0);
     assert(status.category == &amongoc_generic_category);
     assert(*amongoc_box_cast(int*, box) == 42);


### PR DESCRIPTION
This fixes two linker problems:

1. Missing definitions of `inline` functions. The relevant `extern inline` declarations need to appear in C files, not C++ files.
2. Accidental external references to neo-fun components due to stray assertions. This change suppresses the assertions, even in debug mode.

The simple consumer test case is modified to force linking to the external definitions that were missing.