### PR TITLE
Fix build on macOS with clang 19

### DIFF
--- a/include/bson/parse.hpp
+++ b/include/bson/parse.hpp
@@ -15,6 +15,7 @@
 #include <mlib/config.h>
 #include <mlib/object_t.hpp>
 
+#include <algorithm>  // std::ranges::copy
 #include <csignal>
 #include <iterator>
 #include <string>

--- a/include/bson/value_ref.h
+++ b/include/bson/value_ref.h
@@ -10,6 +10,8 @@
 
 #if mlib_is_cxx()
 #include <mlib/type_traits.hpp>
+
+#include <exception>  // std::terminate
 #endif
 
 struct bson_value;

--- a/include/mlib/config.h
+++ b/include/mlib/config.h
@@ -129,8 +129,15 @@
 #define mlib_alignas(T) MLIB_LANG_PICK(_Alignas)(alignas)(T)
 #define mlib_alignof(T) MLIB_LANG_PICK(_Alignof)(alignof)(T)
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+#define mlib_is_little_endian()                                                \
+  mlib_parenthesized_expression(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#elif defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
 #define mlib_is_little_endian()                                                \
   mlib_parenthesized_expression(__BYTE_ORDER == __LITTLE_ENDIAN)
+#else
+#error "Do not know how to detect endianness on this platform."
+#endif
 
 /**
  * @brief Expands to a `thread_local` specifier for the current language

--- a/src/amongoc/coroutine.hpp
+++ b/src/amongoc/coroutine.hpp
@@ -72,7 +72,11 @@ public:
         : _co(other.release()) {}
 
     // Move-assign
-    constexpr unique_co_handle& operator=(unique_co_handle&&) const noexcept { reset(); }
+    constexpr unique_co_handle& operator=(unique_co_handle&& other) const noexcept {
+        reset();
+        this->_co = other.release();
+        return *this;
+    }
 
     ~unique_co_handle() { reset(); }
 

--- a/src/amongoc/coroutine.hpp
+++ b/src/amongoc/coroutine.hpp
@@ -72,7 +72,7 @@ public:
         : _co(other.release()) {}
 
     // Move-assign
-    constexpr unique_co_handle& operator=(unique_co_handle&& other) const noexcept { reset(); }
+    constexpr unique_co_handle& operator=(unique_co_handle&&) const noexcept { reset(); }
 
     ~unique_co_handle() { reset(); }
 

--- a/src/amongoc/handshake.hpp
+++ b/src/amongoc/handshake.hpp
@@ -36,9 +36,6 @@ struct handshake_response {
     // Get the allocator for this object
     mlib::allocator<> get_allocator() const noexcept { return topologyVersion.get_allocator(); }
 
-    // The type of points-in-time
-    using time_point = std::chrono::utc_time<std::chrono::milliseconds>;
-
     // Common response fields
     bool isWritablePrimary = false;
     // TODO: This is not a string
@@ -46,7 +43,6 @@ struct handshake_response {
     std::size_t          maxBsonObjectSize   = 16 * 1024 * 1024;
     std::size_t          maxMessageSizeBytes = 48'000'000;
     std::size_t          maxWriteBatchSize   = 100'000;
-    time_point           localTime;
     std::chrono::minutes logicalSessionTimeoutMinutes{0};
     std::int32_t         connectionId;
     std::int32_t         minWireVersion{0};

--- a/src/bson/types.cpp
+++ b/src/bson/types.cpp
@@ -1,5 +1,7 @@
 #include <bson/types.h>
 
+#include <algorithm>  // std::ranges::equal
+
 bool bson_binary_view::operator==(const bson_binary_view& other) const noexcept {
     return (this->subtype == other.subtype)  //
         and std::ranges::equal(this->bytes_span(), other.bytes_span());

--- a/src/mlib/bytes.hpp
+++ b/src/mlib/bytes.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <ranges>
+#include <system_error>
 #include <type_traits>
 
 namespace mlib {

--- a/src/mlib/invoke.hpp
+++ b/src/mlib/invoke.hpp
@@ -2,6 +2,7 @@
 
 #include <mlib/config.h>
 
+#include <concepts>
 #include <utility>
 
 namespace mlib {

--- a/src/mlib/object_t.hpp
+++ b/src/mlib/object_t.hpp
@@ -2,6 +2,7 @@
 
 #include "./invoke.hpp"
 
+#include <memory>  // std::addressof
 #include <type_traits>
 
 namespace mlib {

--- a/tools/MongoWarnings.cmake
+++ b/tools/MongoWarnings.cmake
@@ -77,7 +77,7 @@ mongo_add_warning_options(
     # Definite use of uninitialized value
     gnu-like:-Werror=uninitialized msvc:/we4700
     # GCC Seems to generate false positives on this. Investigate?
-    gnu-like:-Wno-maybe-uninitialized
+    gnu:-Wno-maybe-uninitialized
 
     # Aside: Disable CRT insecurity warnings
     msvc:/D_CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
I think supporting macOS is more of a nice-to-have than a requirement for the prototype. But this PR adds some changes that seemed like improvements. This fixed build on my macOS machine with clang 19 installed from `homebrew install llvm`:

```bash
# Use clang 19. Export to apply to neo-fun.
export CC=/opt/homebrew/opt/llvm/bin/clang
export CXX=/opt/homebrew/opt/llvm/bin/clang++

# Configure
cmake -DCMAKE_OSX_ARCHITECTURES=arm64  \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
    -B_build -S. "${cmake_opts[@]}"

# Build
cmake --build _build --target amongoc

# Install
cmake --install _build --prefix "$HOME/amongoc-0.1.0"
```

This PR does not address errors encountered linking a client app. I have not-yet explained those:

```
[ 50%] Building C object CMakeFiles/hello-amongoc.dir/hello-amongoc.c.o
[100%] Linking CXX executable hello-amongoc
Undefined symbols for architecture arm64:
  "fmt::v11::report_error(char const*)", referenced from:
      char const* fmt::v11::detail::parse_align<char>(char const*, char const*, fmt::v11::format_specs&) in libamongoc.a(uri.cpp.o)
      char const* fmt::v11::detail::parse_dynamic_spec<char>(char const*, char const*, int&, fmt::v11::detail::arg_ref<char>&, fmt::v11::basic_format_parse_context<char>&) in libamongoc.a(uri.cpp.o)
      char const* fmt::v11::detail::parse_precision<char>(char const*, char const*, int&, fmt::v11::detail::arg_ref<char>&, fmt::v11::basic_format_parse_context<char>&) in libamongoc.a(uri.cpp.o)
      char const* fmt::v11::detail::do_parse_arg_id<char, fmt::v11::detail::dynamic_spec_id_handler<char>&>(char const*, char const*, fmt::v11::detail::dynamic_spec_id_handler<char>&) in libamongoc.a(uri.cpp.o)
      fmt::v11::basic_format_parse_context<char>::check_arg_id(int) in libamongoc.a(uri.cpp.o)
      fmt::v11::basic_format_parse_context<char>::next_arg_id() in libamongoc.a(uri.cpp.o)
[...]
  "neo::ufmt_detail::write_i64(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, long long)", referenced from:
      __ZN3neo11ufmt_appendITkNSt3__18integralElEEvRNS1_12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEET_ in libamongoc.a(connection_pool.cpp.o)
      __ZN3neo11ufmt_appendITkNSt3__18integralElEEvRNS1_12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEET_ in libamongoc.a(proto.cpp.o)
```
