### PR TITLE
fix typos

### DIFF
--- a/docs/dev/bson-building.rst
+++ b/docs/dev/bson-building.rst
@@ -2,11 +2,11 @@
 Declaratively Building BSON Documents
 #####################################
 
-|amongoc|'s BSON library contains a facility for building heirarchies of BSON
+|amongoc|'s BSON library contains a facility for building hierarchies of BSON
 objects declaratively in a single-shot. Usage of this facility is recommended
 for a few reasons:
 
-- It will always "do the right thing" -- Building large heirarchies of data
+- It will always "do the right thing" -- Building large hierarchies of data
   by-hand is tedious and error-prone.
 - The declarative structure mimics the generated data very closely, and is easy
   to understand and modify.
@@ -49,7 +49,7 @@ pair).
 
   .. note:: If you pull the ``bson::parse`` namespace, they both contain a `doc`
     declaration, and you will receive a compiler error about ambiguous name lookup.
-    Pull `bson::make::doc` with a :cpp:`using`, or use the fully-qualifeid name.
+    Pull `bson::make::doc` with a :cpp:`using`, or use the fully-qualified name.
 
   .. function:: bson::document build(mlib::allocator<>)
 
@@ -141,7 +141,7 @@ Low-Level Concepts
 
   .. seealso:: :ref:`bson.make.value-rules`.
 
-  **Any type** that can be inserted using `bson_insert` can be used as an
+  **Any type** that can be inserted using `bson_insert` can be used as a
   `value_rule`.
 
   **Other types** may also satisfy `value_rule` by meeting the below

--- a/docs/dev/bson-parsing.rst
+++ b/docs/dev/bson-parsing.rst
@@ -3,7 +3,7 @@ Declaratively Parsing BSON Objects
 ##################################
 
 |amongoc|'s BSON library contains a submodule for declaratively decomposing
-BSON values and heirarchies declaratively.
+BSON values and hierarchies declaratively.
 
 
 High-Level Constructs

--- a/docs/dev/coroutines.rst
+++ b/docs/dev/coroutines.rst
@@ -1,6 +1,6 @@
-###########
-Couroutines
-###########
+##########
+Coroutines
+##########
 
 .. warning:: |devdocs-page|
 .. namespace:: amongoc
@@ -116,7 +116,7 @@ If an `amongoc_emitter` coroutine throws an exception, the following will happen
 2. Otherwise, if the exception type is derived from an `amongoc::exception`,
    then the `exception::status` will be the result status of the emitter.
 3. Otherwise, if the exception type is `std__bad_alloc`, the emitter
-   will resolve with generic cateogry and ``ENOMEM``.
+   will resolve with generic category and ``ENOMEM``.
 4. Otherwise, **the program will terminate**. *Don't let this happen!*
 
 
@@ -371,7 +371,7 @@ Support Concepts
 
     When the parent coroutine suspends, it will call `await_suspend` with a
     :term:`handle to the coroutine <coroutine handle>` that is being suspended.
-    This give the awaiter the opportunity to reschedule the coroutine at some
+    This gives the awaiter the opportunity to reschedule the coroutine at some
     point in the future. If `await_suspend` returns a new coroutine handle |R|,
     then |R| will be resumed after the enclosing coroutine suspends (this is
     known as *symmetric transfer*). If `await_suspend` returns :cpp:`void`,
@@ -579,7 +579,7 @@ A coroutine promise should implement the following interface:
 
   .. function:: virtual in_place_stop_token stop_token() = 0
 
-    Obtian the stop token for use with the coroutine.
+    Obtain the stop token for use with the coroutine.
 
 .. struct:: template <typename T> co_task<T>::promise_type : coroutine_promise_allocator_mixin
 

--- a/docs/dev/documenting.rst
+++ b/docs/dev/documenting.rst
@@ -73,7 +73,7 @@ External ``cppreference`` Links
 We use a custom-generated Sphinx inventory for objects documented on
 cppreference, because at time of writing, ``cppreference`` does not have a
 Sphinx inventory of its own. This inventory is generated with code in
-``docs/conf.py`` on-the-fly when documentation is buidt. Linking to external
+``docs/conf.py`` on-the-fly when documentation is built. Linking to external
 items requires that they are present in the custom inventory. If a link fails to
 generate, ensure it is present in the custom inventory.
 

--- a/docs/dev/guidelines.rst
+++ b/docs/dev/guidelines.rst
@@ -72,7 +72,7 @@ compilation should be localized to the smallest lexical scope required.
 Use terse conditional compilation
 *********************************
 
-Prever to use :c:macro:`MLIB_IF_CXX` and :c:macro:`MLIB_IF_NOT_CXX` for more
+Prefer to use :c:macro:`MLIB_IF_CXX` and :c:macro:`MLIB_IF_NOT_CXX` for more
 concise conditional compilation/macro expansions.
 
 
@@ -163,8 +163,8 @@ semicolons when a user adds a semicolon to a macro expansion that doesn't need
 one.
 
 
-Add comments to distant :cpp:`endif` and :cpp:`#else` directives
-****************************************************************
+Add comments to distant :cpp:`#endif` and :cpp:`#else` directives
+*****************************************************************
 
 If an :cpp:`#endif` or :cpp:`#else` directive is far away from its associated
 conditional, add a comment explaining what it's for::

--- a/docs/dev/queries.rst
+++ b/docs/dev/queries.rst
@@ -109,7 +109,7 @@ P2300 also defines query objects and query types, but with a few important
 differences:
 
 1. Queryable objects in P2300 may define a separate *environment* object so that
-   their queries can be performed on a separate instance from the underyling
+   their queries can be performed on a separate instance from the underlying
    object. Our querying code does not use separate environments, as we don't yet
    have a need for this. This may be added later if the need arises.
 2. P2300 queries can carry additional arguments to the ``query`` methods. We

--- a/docs/dev/result.rst
+++ b/docs/dev/result.rst
@@ -13,7 +13,7 @@
 
   .. type::
     success_type = T
-    error_type = T
+    error_type = E
 
     The success type and error type of the result, respectively.
 
@@ -25,8 +25,8 @@
     result(U&& arg)
 
     Conditionally-explicit converting constructor. Requires that `U` is
-    explicit-convertbile to `T` *but not* explicit-convertible to `E`. This
-    constructor is explicit unless `U` is implicit-convertbile to `T`.
+    explicit-convertible to `T` *but not* explicit-convertible to `E`. This
+    constructor is explicit unless `U` is implicit-convertible to `T`.
 
   .. function::
     template <typename... Args> \
@@ -37,7 +37,7 @@
     In-place constructs a success value or an error value, respectively.
 
     :param tag: The tag contains a tuple of bound constructor arguments that will
-      be forwarded to consrtuct the underlying object.
+      be forwarded to construct the underlying object.
 
     This requires that the corresponding contained type be constructible from
     the argument types that are bound within the tag.

--- a/docs/dev/tls.rst
+++ b/docs/dev/tls.rst
@@ -15,7 +15,7 @@ BIO, it just expects it to behave like a stream of bytes.
 Any I/O operation on the high-level TLS stream can be composed of an arbitrary
 number of reads and writes to the actual underlying stream. As such, it is not
 as simple as reading/writing data into the :struct:`SSL` and then receiving some
-plaintext/cyphertext. A single read or write of plaintext may invoke more reads
+plaintext/ciphertext. A single read or write of plaintext may invoke more reads
 or writes on the ciphertext stream, so the |amongoc| wrapper's read/write
 operations need to be able to handle such a situation.
 

--- a/docs/explain/consider.rst
+++ b/docs/explain/consider.rst
@@ -42,10 +42,10 @@ is invoked simultaneously? What APIs are thread-safe?
 All APIs *are* reentrant, but only because
 :ref:`they are written without shared state <no-globals>`.
 
-Additionally, becuase we have :ref:`no prescribed event loop <prescribe-loop>`,
+Additionally, because we have :ref:`no prescribed event loop <prescribe-loop>`,
 it is entirely up to the user on which thread(s) of execution their code will
 execute. We do not require the user bring their own thread to pump any global
-even loop.
+event loop.
 
 
 .. _prescribe-loop:


### PR DESCRIPTION
Drive-by fixes after a re-read of developer docs. Though I expect these may be soon out-dated with changes to the prototype.