### PR TITLE
parse replica set hello

### DIFF
--- a/src/amongoc/handshake.cpp
+++ b/src/amongoc/handshake.cpp
@@ -61,9 +61,8 @@ amongoc::handshake_response amongoc::handshake_response::parse(mlib::allocator<>
             field("saslSupportedMechs", must(append_strings(ret.saslSupportedMechs))),
             field("hosts", must(append_strings(ret.hosts))),
             field("setName", must(store_string(ret.setName))),
-            field("setVersion", must(store_string(ret.setVersion))),
-            field("secondary", must(integer(store(ret.setVersion)))),
-            field("secondary", must(integer(store(ret.setVersion)))),
+            field("setVersion", must(integer(store(ret.setVersion)))),
+            field("secondary", must(store(ret.secondary))),
             field("passives", must(append_strings(ret.passives))),
             field("arbiters", must(append_strings(ret.arbiters))),
             field("primary", must(store_string(ret.primary))),
@@ -71,7 +70,7 @@ amongoc::handshake_response amongoc::handshake_response::parse(mlib::allocator<>
             field("passive", must(integer(store(ret.passive)))),
             field("hidden", must(integer(store(ret.hidden)))),
             field("me", must(store_string(ret.me))),
-            field("electionId", must(store_string(ret.electionId))),
+            field("electionId", bson::parse::just_accept{}),  // TODO
             field("msg", must(store_string(ret.msg))),
             // TODO: lastWrite, tags
             bson::parse::just_accept{},


### PR DESCRIPTION
To address an observed "Protocol error" encountered when testing locally against a replica set. Supports parsing the `hello` from this response:

```json
{
  "topologyVersion": {
    "processId": ObjectID(694180681cd5f2fb5cedced8),
    "counter": 6:i64,
  },
  "hosts": [
    "localhost:27017",
  ],
  "setName": "rs0",
  "setVersion": 1:i32,
  "isWritablePrimary": true,
  "secondary": false,
  "primary": "localhost:27017",
  "me": "localhost:27017",
  "electionId": ObjectID(7fffffff0000000000000001),
  "lastWrite": {
    "opTime": {
      "ts": Timestamp(⟨1765902284s⟩ : 1),
      "t": 1:i64,
    },
    "lastWriteDate": Datetime⟨UTC+1765902284000ms⟩,
    "majorityOpTime": {
      "ts": Timestamp(⟨1765902284s⟩ : 1),
      "t": 1:i64,
    },
    "majorityWriteDate": Datetime⟨UTC+1765902284000ms⟩,
  },
  "maxBsonObjectSize": 16777216:i32,
  "maxMessageSizeBytes": 48000000:i32,
  "maxWriteBatchSize": 100000:i32,
  "localTime": Datetime⟨UTC+1765902294043ms⟩,
  "logicalSessionTimeoutMinutes": 30:i32,
  "connectionId": 35:i32,
  "minWireVersion": 0:i32,
  "maxWireVersion": 25:i32,
  "readOnly": false,
  "ok": 1:f64,
  "$clusterTime": {
    "clusterTime": Timestamp(⟨1765902284s⟩ : 1),
    "signature": {
      "hash": Binary(subtype 0, bytes 0x0000000000000000000000000000000000000000),
      "keyId": 0:i64,
    },
  },
  "operationTime": Timestamp(⟨1765902284s⟩ : 1),
}
```